### PR TITLE
WIP: Fix/streamline network config

### DIFF
--- a/environment.ts
+++ b/environment.ts
@@ -1,54 +1,19 @@
 import Constants from "expo-constants";
-import daiAbi from "./resources/contracts/DaiToken.json";
-import abi from "./resources/contracts/SinglePlayerCommit.json";
+
 
 interface EnvironmentProps {
-  spcAbi: any;
-  daiAbi: any;
-  spcAddress: string;
-  daiAddress: string;
-  linkAddress: string;
-  rpcUrl: string;
-  biconomyApiKey?: string;
-  host: string;
-  chainId: number;
-  networkName: string;
   debug: boolean;
-  nativeToken: string;
 }
 
 const ENV = {
   dev: {
-    spcAbi: abi,
-    daiAbi: daiAbi,
-    spcAddress: "0x6B6FD55b224b25B2F56A10Ce670B097e66Fca136",
-    daiAddress: "0x70d1F773A9f81C852087B77F6Ae6d3032B02D2AB",
-    // daiAddress: "0x6A383cf1F8897585718DCA629a8f1471339abFe4",
-    linkAddress: "0x70d1F773A9f81C852087B77F6Ae6d3032B02D2AB",
-    rpcUrl:
-      "https://polygon-mumbai.infura.io/v3/3c072dd341bb4e45858038e146195ae1",
-    biconomyApiKey: "V7nbIe8Ue.94e3d8fd-2f0d-42cc-96aa-27d57dac9a7c",
-    host: "mumbai",
-    chainId: 80001,
-    networkName: "Mumbai",
     debug: true,
-    nativeToken: "MATIC",
   },
   prod: {
-    spcAbi: abi,
-    daiAbi: daiAbi,
-    spcAddress: "0x91E17f2A995f7EB830057a2F83ADa3A50a37F20d",
-    daiAddress: "0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063",
-    linkAddress: "0xb0897686c545045aFc77CF20eC7A532E3120E0F1",
-    rpcUrl:
-      "https://polygon-mainnet.infura.io/v3/3c072dd341bb4e45858038e146195ae1",
-    host: "matic",
-    chainId: 137,
-    networkName: "Matic Network",
     debug: false,
-    nativeToken: "MATIC",
   },
 };
+
 const getEnvVars = (env = Constants.manifest.releaseChannel) => {
   // What is __DEV__ ?
   // This variable is set to true when react-native is running in Dev mode.

--- a/hooks/useActivities.ts
+++ b/hooks/useActivities.ts
@@ -6,6 +6,7 @@ import { formatActivities } from "../utils/commitment";
 import { Contract } from "ethers";
 
 import { updateActivities } from "../redux/commitpool/commitpoolSlice";
+import useContracts from "./useContracts";
 
 const useActivities = () => {
   const [loading, setLoading] = useState<boolean>(true);
@@ -13,9 +14,7 @@ const useActivities = () => {
     (state: RootState) => state.commitpool.activities
   );
 
-  const spcContract: Contract = useSelector(
-    (state: RootState) => state.web3.contracts.singlePlayerCommit
-  );
+  const { spcContract } = useContracts();
 
   const [formattedActivities, setFormattedActivities] = useState<
     DropdownItem[]
@@ -27,31 +26,31 @@ const useActivities = () => {
 
   // Get activities from contract
   useEffect(() => {
-    const buildActivityArray = async () => {
-      const _activities: Activity[] = [];
-      let loading: boolean = true;
-      let index: number = 0;
-
-      while (loading) {
-        try {
-          const key = await spcContract.activityKeyList(index);
-          const activity = await spcContract.activities(key);
-          if (activity.exists && activity.allowed) {
-            const clone = Object.assign({}, activity);
-            clone.key = key;
-            clone.name = activity.name;
-            _activities.push(clone as Activity);
-          }
-          index++;
-        } catch (error) {
-          loading = false;
-        }
-      }
-
-      return _activities;
-    };
-
     if (spcContract && loading) {
+      const buildActivityArray = async () => {
+        const _activities: Activity[] = [];
+        let loading: boolean = true;
+        let index: number = 0;
+
+        while (loading) {
+          try {
+            const key = await spcContract.activityKeyList(index);
+            const activity = await spcContract.activities(key);
+            if (activity.exists && activity.allowed) {
+              const clone = Object.assign({}, activity);
+              clone.key = key;
+              clone.name = activity.name;
+              _activities.push(clone as Activity);
+            }
+            index++;
+          } catch (error) {
+            loading = false;
+          }
+        }
+
+        return _activities;
+      };
+
       buildActivityArray().then((array) => {
         console.log("ActivityArray: ", array);
         dispatch(updateActivities(array));

--- a/hooks/useCommitment.ts
+++ b/hooks/useCommitment.ts
@@ -31,7 +31,7 @@ const useCommitment = () => {
     getActivityName(commitment.activityKey, activities) || "";
 
   const refreshCommitment = async () => {
-    if (account) {
+    if (account && spcContract) {
       const commitment = await spcContract.commitments(account);
       const _commitment: Commitment = parseCommitmentFromContract(commitment);
       dispatch(updateCommitment({ ..._commitment }));

--- a/hooks/useCommitment.ts
+++ b/hooks/useCommitment.ts
@@ -16,7 +16,7 @@ import useWeb3 from "./useWeb3";
 const useCommitment = () => {
   const dispatch = useAppDispatch();
   const { activities } = useActivities();
-  const { singlePlayerCommit } = useContracts();
+  const { spcContract } = useContracts();
   const { account } = useWeb3();
 
   const commitment: Commitment = useSelector(
@@ -32,7 +32,7 @@ const useCommitment = () => {
 
   const refreshCommitment = async () => {
     if (account) {
-      const commitment = await singlePlayerCommit.commitments(account);
+      const commitment = await spcContract.commitments(account);
       const _commitment: Commitment = parseCommitmentFromContract(commitment);
       dispatch(updateCommitment({ ..._commitment }));
     }

--- a/hooks/useContracts.ts
+++ b/hooks/useContracts.ts
@@ -1,15 +1,36 @@
-import { useSelector } from "react-redux";
-import { RootState } from "../redux/store";
-
-import { Contract } from 'ethers';
-import { useEffect } from "react";
+import { Contract, ethers } from "ethers";
+import { useEffect, useState } from "react";
 import useWeb3 from "./useWeb3";
 
-const useContracts = ()=> {
-  const { dai, singlePlayerCommit } = useSelector((state: RootState) => state.web3.contracts);
+import daiAbi from "../resources/contracts/DaiToken.json";
+import abi from "../resources/contracts/SinglePlayerCommit.json";
 
-  return { dai, singlePlayerCommit}
+const useContracts = () => {
+  const { chain, provider } = useWeb3();
+  const [daiContract, setDaiContract] = useState<Contract>();
+  const [spcContract, setSpcContract] = useState<Contract>();
+  
+  useEffect(() => {
+    if (chain?.spcAddress && chain?.daiAddress) {
+      const dai = new ethers.Contract(chain.daiAddress, daiAbi, provider);
+      const spc = new ethers.Contract(chain.spcAddress, abi, provider);
 
-}
+      setDaiContract(dai);
+      setSpcContract(spc);
+    }
+  }, [chain]);
+
+  useEffect(() => {
+    if (provider?.getSigner() && daiContract && spcContract) {
+      const dai = daiContract.connect(provider.getSigner());
+      const spc = spcContract.connect(provider.getSigner());
+
+      setDaiContract(dai);
+      setSpcContract(spc);
+    }
+  }, [provider]);
+
+  return { daiContract, spcContract };
+};
 
 export default useContracts;

--- a/hooks/useContracts.ts
+++ b/hooks/useContracts.ts
@@ -12,8 +12,8 @@ const useContracts = () => {
   
   useEffect(() => {
     if (chain?.spcAddress && chain?.daiAddress) {
-      const dai = new ethers.Contract(chain.daiAddress, daiAbi, provider);
-      const spc = new ethers.Contract(chain.spcAddress, abi, provider);
+      const dai: Contract = new ethers.Contract(chain.daiAddress, daiAbi, provider);
+      const spc: Contract = new ethers.Contract(chain.spcAddress, abi, provider);
 
       setDaiContract(dai);
       setSpcContract(spc);
@@ -22,8 +22,8 @@ const useContracts = () => {
 
   useEffect(() => {
     if (provider?.getSigner() && daiContract && spcContract) {
-      const dai = daiContract.connect(provider.getSigner());
-      const spc = spcContract.connect(provider.getSigner());
+      const dai: Contract = daiContract.connect(provider.getSigner());
+      const spc: Contract = spcContract.connect(provider.getSigner());
 
       setDaiContract(dai);
       setSpcContract(spc);

--- a/hooks/useWeb3.ts
+++ b/hooks/useWeb3.ts
@@ -6,7 +6,6 @@ import {
   setLoggedIn,
   updateAccount,
   updateChain,
-  updateContracts,
   updateProvider,
   updateWeb3Modal,
   Web3State,
@@ -15,7 +14,7 @@ import {
   updateTransactions,
   TransactionState,
 } from "../redux/transactions/transactionSlice";
-import { Contract, ethers, Transaction } from "ethers";
+import { ethers, Transaction } from "ethers";
 import Web3Modal from "web3modal";
 import { supportedChains } from "../utils/chain";
 import {
@@ -30,8 +29,7 @@ const Web3Instance = () => {
   const transactions: TransactionState = useSelector(
     (state: RootState) => state.transactions
   );
-  const { account, provider, isLoggedIn } = web3;
-  const { dai, singlePlayerCommit } = web3.contracts;
+  const { account, provider, isLoggedIn, chain } = web3;
 
   const hasListeners: any = useRef(null);
 
@@ -87,25 +85,14 @@ const Web3Instance = () => {
 
     //TODO Timeout for Torus provider to populate the selectedAddress
     setTimeout(() => {
-      if (provider?.selectedAddress) {
+      if (web3?.provider?.selectedAddress) {
         console.log("Dispatching updated Web3 config");
         console.log("Provider: ", provider);
         console.log("Address: ", provider.selectedAddress);
-
-        const _dai: Contract = dai.connect(web3.getSigner());
-        const _singlePlayerCommit: Contract = singlePlayerCommit.connect(
-          web3.getSigner()
-        );
-        dispatch(updateProvider(provider));
+        dispatch(updateProvider(web3));
         dispatch(updateAccount(provider.selectedAddress));
         dispatch(updateChain(chain));
         dispatch(updateWeb3Modal(localWeb3Modal));
-        dispatch(
-          updateContracts({
-            dai: _dai,
-            singlePlayerCommit: _singlePlayerCommit,
-          })
-        );
         dispatch(setLoggedIn(true));
       }
     }, 2000);
@@ -165,11 +152,12 @@ const Web3Instance = () => {
 
   return {
     account,
-    provider,
-    requestWallet,
-    transactions,
+    chain,
     isLoggedIn,
+    provider,
+    transactions,
     getTransaction,
+    requestWallet,
     storeTransactionToState,
   };
 };
@@ -177,21 +165,23 @@ const Web3Instance = () => {
 const useWeb3 = () => {
   const {
     account,
-    provider,
+    chain,
     isLoggedIn,
+    provider,
     transactions,
-    requestWallet,
     getTransaction,
+    requestWallet,
     storeTransactionToState,
   } = Web3Instance();
 
   return {
     account,
-    provider,
+    chain,
     isLoggedIn,
+    provider,
     transactions,
-    requestWallet,
     getTransaction,
+    requestWallet,
     storeTransactionToState,
   };
 };

--- a/redux/web3/web3Slice.ts
+++ b/redux/web3/web3Slice.ts
@@ -11,7 +11,7 @@ export interface Web3State {
   chain?: Network;
 }
 
-//TODO pretty way for default RPC for generic provider (used to read activities on app load)
+//Polygon as default network
 const defaultChain: Network = chainByNetworkId('137');
 const defaultProvider = ethers.getDefaultProvider(defaultChain.rpc_url);
 console.log('Default provider :', defaultProvider);

--- a/redux/web3/web3Slice.ts
+++ b/redux/web3/web3Slice.ts
@@ -1,34 +1,22 @@
 import { createSlice, PayloadAction, Slice } from "@reduxjs/toolkit";
-import { ethers, Contract } from "ethers";
-import getEnvVars from "../../environment";
+import { ethers } from "ethers";
 import Web3Modal from "web3modal";
-
-const { spcAbi, daiAbi, daiAddress, spcAddress, rpcUrl } = getEnvVars();
+import { chainByNetworkId } from "../../utils/chain";
 
 export interface Web3State {
-  account?: string;
-  contracts: {
-    dai: Contract;
-    singlePlayerCommit: Contract;
-  };
   provider: any;
   isLoggedIn: boolean;
+  account?: string;
   web3Modal?: Web3Modal;
   chain?: Network;
 }
 
-const defaultProvider = ethers.getDefaultProvider(rpcUrl);
-console.log(defaultProvider);
+//TODO pretty way for default RPC for generic provider (used to read activities on app load)
+const defaultChain: Network = chainByNetworkId('137');
+const defaultProvider = ethers.getDefaultProvider(defaultChain.rpc_url);
+console.log('Default provider :', defaultProvider);
 
 const initialState: Web3State = {
-  contracts: {
-    dai: new ethers.Contract(daiAddress, daiAbi, defaultProvider),
-    singlePlayerCommit: new ethers.Contract(
-      spcAddress,
-      spcAbi,
-      defaultProvider
-    ),
-  },
   provider: defaultProvider,
   isLoggedIn: false,
 };
@@ -37,12 +25,6 @@ export const web3Slice: Slice = createSlice({
   name: "web3",
   initialState,
   reducers: {
-    updateContracts: (state, action) => {
-      state.contracts = {
-        ...state.contracts,
-        ...action.payload,
-      };
-    },
     updateProvider: (state, action) => {
       state.provider = action.payload;
     },

--- a/types.d.ts
+++ b/types.d.ts
@@ -41,6 +41,9 @@ interface Network {
   rpc_url: string;
   block_explorer: string;
   hub_sort_order?: number;
+  spcAddress?: string;
+  daiAddress?: string;
+  linkAddress?: string;
 }
 
 type TransactionTypes =

--- a/utils/chain.ts
+++ b/utils/chain.ts
@@ -3,41 +3,8 @@ interface SupportedChains {
 }
 
 export const supportedChains: SupportedChains = {
-  "0x1": {
-    name: "Ethereum Mainnet",
-    short_name: "eth",
-    chain: "ETH",
-    network: "mainnet",
-    network_id: 1,
-    chain_id: "0x1",
-    providers: ["walletconnect", "torus"],
-    rpc_url: `https://mainnet.infura.io/v3/3c072dd341bb4e45858038e146195ae1`,
-    block_explorer: "https://etherscan.io",
-  },
-  "0x4": {
-    name: "Ethereum Rinkeby",
-    short_name: "rin",
-    chain: "ETH",
-    network: "rinkeby",
-    network_id: 4,
-    chain_id: "0x4",
-    providers: ["walletconnect", "torus"],
-    rpc_url: `https://rinkeby.infura.io/v3/3c072dd341bb4e45858038e146195ae1`,
-    block_explorer: "https://rinkeby.etherscan.io",
-  },
-  "0x2a": {
-    name: "Ethereum Kovan",
-    short_name: "kov",
-    chain: "ETH",
-    network: "kovan",
-    network_id: 42,
-    chain_id: "0x2a",
-    providers: ["walletconnect", "torus"],
-    rpc_url: `https://kovan.infura.io/v3/3c072dd341bb4e45858038e146195ae1`,
-    block_explorer: "https://kovan.etherscan.io",
-  },
   "0x89": {
-    name: "Matic",
+    name: "Polygon",
     short_name: "matic",
     chain: "MATIC",
     network: "matic",
@@ -47,6 +14,9 @@ export const supportedChains: SupportedChains = {
     rpc_url:
       "https://polygon-mainnet.infura.io/v3/3c072dd341bb4e45858038e146195ae1",
     block_explorer: "https://polygonscan.com",
+    spcAddress: "0x91E17f2A995f7EB830057a2F83ADa3A50a37F20d",
+    daiAddress: "0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063",
+    linkAddress: "0xb0897686c545045aFc77CF20eC7A532E3120E0F1"
   },
   "0x13881": {
     name: "Matic Mumbai",
@@ -59,15 +29,15 @@ export const supportedChains: SupportedChains = {
     rpc_url:
       "https://polygon-mumbai.infura.io/v3/3c072dd341bb4e45858038e146195ae1",
     block_explorer: "https://mumbai.polygonscan.com",
+    spcAddress: "0x6B6FD55b224b25B2F56A10Ce670B097e66Fca136",
+    daiAddress: "0x70d1F773A9f81C852087B77F6Ae6d3032B02D2AB",
+    linkAddress: "0x70d1F773A9f81C852087B77F6Ae6d3032B02D2AB",
   },
 };
 
 export const chainByID = (chainId: string): Network => supportedChains[chainId];
 export const chainByNetworkId = (networkId: string): Network => {
   const idMapping: any = {
-    1: supportedChains["0x1"],
-    4: supportedChains["0x4"],
-    42: supportedChains["0x2a"],
     137: supportedChains["0x89"],
     80001: supportedChains["0x13881"],
   };

--- a/utils/commitment.ts
+++ b/utils/commitment.ts
@@ -1,52 +1,50 @@
 import { ethers } from "ethers";
 
-const getActivityName = (activityKey: string, activities: Activity[]): string => {
+const getActivityName = (
+  activityKey: string,
+  activities: Activity[]
+): string => {
   const activity = activities.find((activity) => activity.key === activityKey);
   return activity?.name || "";
 };
 
 const formatActivities = (activities: Activity[]): DropdownItem[] => {
   const formattedActivities = activities.map((act: Activity) => {
-      if (act.name === "Run") {
-        return {
-          label: "Run 🏃‍♂️",
-          value: act.key,
-        };
-      } else if (act.name === "Ride") {
-        return {
-          label: "Ride 🚲",
-          value: act.key,
-        };
-      } else {
-        return {
-          label: act.name,
-          value: act.key,
-        };
-      }
-    });
+    if (act.name === "Run") {
+      return {
+        label: "Run 🏃‍♂️",
+        value: act.key,
+      };
+    } else if (act.name === "Ride") {
+      return {
+        label: "Ride 🚲",
+        value: act.key,
+      };
+    } else {
+      return {
+        label: act.name,
+        value: act.key,
+      };
+    }
+  });
 
   return formattedActivities;
 };
 
-const parseCommitmentFromContract = (commitment: any): Commitment | undefined => {
-  try {
-    const _commitment: Commitment = {
-      activityKey: commitment.activityKey,
-      goalValue: Number.parseFloat(commitment.goalValue) / 100,
-      reportedValue: Number.parseFloat(commitment.reportedValue) / 100,
-      endTime: Number.parseFloat(commitment.endTime.toString()),
-      startTime: Number.parseFloat(commitment.startTime.toString()),
-      stake: Number.parseFloat(ethers.utils.formatEther(commitment.stake)),
-      exists: commitment.exists,
-      met: commitment.met,
-      unit: "mi",
-    };
-    console.log("Parsed commitment: ", _commitment);
-    return _commitment
-  } catch (e) {
-    console.log(e);
-    return undefined;
-  }
+const parseCommitmentFromContract = (commitment: any): Commitment => {
+  const _commitment: Commitment = {
+    activityKey: commitment.activityKey,
+    goalValue: Number.parseFloat(commitment.goalValue) / 100,
+    reportedValue: Number.parseFloat(commitment.reportedValue) / 100,
+    endTime: Number.parseFloat(commitment.endTime.toString()),
+    startTime: Number.parseFloat(commitment.startTime.toString()),
+    stake: Number.parseFloat(ethers.utils.formatEther(commitment.stake)),
+    exists: commitment.exists,
+    met: commitment.met,
+    unit: "mi",
+  };
+  console.log("Parsed commitment: ", _commitment);
+  return _commitment;
 };
 
 const validActivityKey = (

--- a/utils/web3Modal.ts
+++ b/utils/web3Modal.ts
@@ -24,9 +24,7 @@ const addNetworkProviders = (chainData: Network) => {
       package: WalletConnectProvider,
       options: {
         rpc: {
-          1: `https://mainnet.infura.io/v3/3c072dd341bb4e45858038e146195ae1`,
           4: `https://rinkeby.infura.io/v3/3c072dd341bb4e45858038e146195ae1`,
-          42: `https://kovan.infura.io/v3/3c072dd341bb4e45858038e146195ae1`,
           137: "https://polygon-mainnet.infura.io/v3/3c072dd341bb4e45858038e146195ae1",
           80001:
             "https://polygon-mumbai.infura.io/v3/3c072dd341bb4e45858038e146195ae1",
@@ -36,7 +34,6 @@ const addNetworkProviders = (chainData: Network) => {
   }
 
   if (providersToAdd.includes("torus")) {
-    console.log("chainData for Torus provider: ", chainData);
     allProviders.torus = {
       // network: chainData.network,
       package: Torus,
@@ -48,7 +45,6 @@ const addNetworkProviders = (chainData: Network) => {
         },
         config: {
           buildEnv: "production",
-
           showTorusButton: true,
         },
       },

--- a/utils/web3Modal.ts
+++ b/utils/web3Modal.ts
@@ -9,9 +9,10 @@ const isInjected = () => {
 };
 
 export const attemptInjectedChainData = () =>
-  isInjected() ? chainByID(window.ethereum.chainId) : chainByID("0x1");
+  isInjected() ? chainByID(window.ethereum.chainId) : chainByID("137");
 
 const addNetworkProviders = (chainData: Network) => {
+  console.log('ChainData: ', chainData);
   const allProviders: any = {};
   if (!chainData) {
     // this will fire if window.ethereum exists, but the user is on the wrong chain
@@ -24,7 +25,6 @@ const addNetworkProviders = (chainData: Network) => {
       package: WalletConnectProvider,
       options: {
         rpc: {
-          4: `https://rinkeby.infura.io/v3/3c072dd341bb4e45858038e146195ae1`,
           137: "https://polygon-mainnet.infura.io/v3/3c072dd341bb4e45858038e146195ae1",
           80001:
             "https://polygon-mumbai.infura.io/v3/3c072dd341bb4e45858038e146195ae1",


### PR DESCRIPTION
* cleaned up supported networks
* updated default network
* refactored contract hooks

TODO:
Refactoring decision tree for provider/network config
    - Let app always connect provider to e.g. Polygon mainnet
    - If selected web3modal provider is MetaMask, but MM is on unsupported network, display network with error(box/modal/toast) to tell user to switch to supported network (Polygon Mainnet) and implement this flow using the MM RPC API to add/switch network: https://docs.metamask.io/guide/rpc-api.html#other-rpc-methods
    - Something similar is done in DAOHaus, see screenshots
<img width="565" alt="Screenshot 2021-08-13 at 13 20 49" src="https://user-images.githubusercontent.com/19667964/129767353-4d4c9ed4-ea81-496d-8b06-21d5341cb482.png">
<img width="676" alt="Screenshot 2021-08-13 at 13 20 31" src="https://user-images.githubusercontent.com/19667964/129767356-2b9acbbb-b23a-48f3-9de1-6464b82803fd.png">
